### PR TITLE
npm-ci build <build-type>

### DIFF
--- a/bin/npm-ci-build.js
+++ b/bin/npm-ci-build.js
@@ -1,13 +1,17 @@
-import {execCommand, readJsonFile} from '../src/utils';
 import {build} from '../src/build';
-import {get} from 'lodash';
+import {release} from '../src/release';
 
-const pkg = readJsonFile('package.json');
+const program = require('commander');
 
-build();
+program.version(require('../../package').version)
+  .usage('[build-type]')
+  .parse(process.argv);
 
-if (process.env.agentType === 'pullrequest') {
-  execCommand('npm run pr-release --if-present');
-} else if (get(pkg, 'scripts.customPublish')) {
-  execCommand('npm run release --if-present');
+const buildType = program.args[0];
+
+if (buildType) {
+  build(buildType);
+} else {
+  build('test');
+  release();
 }

--- a/src/build.js
+++ b/src/build.js
@@ -6,7 +6,7 @@ function npmVersion() {
   return parseFloat(execSync('npm --version | cut -d. -f1,2').toString());
 }
 
-export function build() {
+export function build(buildType) {
   if (process.env.APPLITOOLS_GITHUB_FT) {
     setApplitoolsId();
   }
@@ -30,5 +30,5 @@ export function build() {
     execCommand('npm run pr-postbuild --if-present');
   }
 
-  execCommand('npm test');
+  execCommand(`npm run ${buildType}`);
 }

--- a/src/release.js
+++ b/src/release.js
@@ -1,0 +1,12 @@
+import {execCommand, readJsonFile} from './utils';
+import {get} from 'lodash';
+
+const pkg = readJsonFile('package.json');
+
+export function release() {
+  if (process.env.agentType === 'pullrequest') {
+    execCommand('npm run pr-release --if-present');
+  } else if (get(pkg, 'scripts.customPublish')) {
+    execCommand('npm run release --if-present');
+  }
+}


### PR DESCRIPTION
This change supposes to give the CI the ability to create dynamic builds using the following API:

```sh
npm-ci build <build-type>
```

__for example:__

The following command will build the app and will run the command `npm run e2e` in the end. (instead of `npm run test` which is the default)

```sh
npm-ci build e2e
```

`build` accepts an argument which decides on the npm script that will run after this build.

When running a custom build there will be no release step.

* This change suppose to be completely backward compatible, and only adds an opt-in feature.