### PR TITLE
More verbose logging, when deciding between `yarn install`/`npm install`/`npm ci`

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -12,16 +12,25 @@ export function build(buildType) {
   }
 
   if (fileExists('yarn.lock')) {
+    console.log('yarn.lock exists, runing `yarn install`');
     execCommand('yarn install --frozen-lockfile', 'yarn install', 2);
+
   } else if (fileExists('.yarnrc')) {
+    console.log('.yarnrc exists, runing `yarn install`');
     execCommand('yarn install', 'yarn install', 2);
+
   } else if (fileExists('package-lock.json')) {
-    if (npmVersion() >= 5.7) {
+    const currentNpmVersion = npmVersion();
+    if (currentNpmVersion >= 5.7) {
+      console.log(`package-lock.json exists and npm version is ${currentNpmVersion}, running \`npm ci\``);
       execCommand('npm ci --cache ~/.npm.$(npm --version)', 'npm ci', 2);
     } else {
+      console.log(`package-lock.json exists but npm version ${currentNpmVersion} is smaller than 5.7, running \`npm install\``);
       execCommand('npm install --cache ~/.npm.$(npm --version)', 'npm install', 2);
     }
+    
   } else {
+    console.log('there is no lock-files, running `npm install`');
     execCommand('npm install --no-package-lock --cache ~/.npm.$(npm --version)', 'npm install', 2);
   }
   execCommand('npm run build --if-present');


### PR DESCRIPTION
We several times faced an issue, when CI executed `npm install`, despite existing `package-lock.json`.
More verbose logging may help to understand reasons of this.
Example issue: https://jira.wixpress.com/browse/CI-12748