### PR TITLE
Try to publish unscoped packages too

### DIFF
--- a/src/publish-scoped.js
+++ b/src/publish-scoped.js
@@ -87,6 +87,7 @@ function verifyWixPackage(packageName) {
 
 function publishUnscopedPackage(originalPackage) {
   const unscopedPackage = {...originalPackage, name: unscope(originalPackage.name)};
+  updateLockFiles(unscopedPackage.name);
   if (!verifyWixPackage(unscopedPackage.name)) {
     console.log('Skipping publishing unscoped package: not a Wix package');
   } else {

--- a/src/publish-scoped.js
+++ b/src/publish-scoped.js
@@ -64,6 +64,19 @@ function updateLockFiles(packageName) {
   updateLockFileIfExists('package-lock.json', packageName);
 }
 
+// Verifies if a given package name is an internal Wix package
+// by looking into the latest version `publishConfig.registry` configuration
+// in `package.json`
+//
+// Examples:
+//   > verifyWixPackage('this-package-surely-doesnt-exist')
+//   false
+//
+//   > verifyWixPackage('react')
+//   false
+//
+//   > verifyWixPackage('santa-core-utils')
+//   true
 function verifyWixPackage(packageName) {
   try {
     const result = execSync(

--- a/src/publish-scoped.js
+++ b/src/publish-scoped.js
@@ -66,7 +66,7 @@ function updateLockFiles(packageName) {
 
 function verifyWixPackage(packageName) {
   const result = execSync(`npm view ${packageName} publishConfig.registry`).toString();
-  return (
+  return Boolean(
     result.includes('npm.dev.wixpress.com') ||
     result.match(/https?:\/\/repo.dev.wix\//)
   );

--- a/src/publish-scoped.js
+++ b/src/publish-scoped.js
@@ -120,7 +120,7 @@ export function publishScoped() {
       publishToRegistry(pkg, 'http://npm.dev.wixpress.com/');
       if (!isScoped(bkp.name)) {
         publishToRegistry(pkg, 'https://registry.npmjs.org/');
-      } else if (process.env.PUBLISH_UNSCOPED === 'true') {
+      } else if (bkp.publishUnscoped) {
         publishUnscopedPackage(bkp);
       }
 


### PR DESCRIPTION
This is a part of the movement towards scoped packages in all of Wix, to support a gradual conversion of packages.
tl;dr: right now, when we publish `package-a`, we also publish `@wix/package-a`. Let's do the opposite too: `@wix/package-a -> package-a`. We should be careful, so `@wix/draft-js` won't be published internally as `draft-js`.
This way, we could convert infra packages first.

## 🌮 Current Behavior

* package name (in `package.json`) is `package-a`
  * Wix internal registry will publish:
    * `package-a`
    * `@wix/package-a`
  * Public npm registry will publish:
    * `@wix/package-a`
* package name (in `package.json`) is `@wix/package-a`
  * Wix internal registry will publish:
    * `@wix/package-a`
  * Public npm registry will publish:
    * `@wix/package-a`

## 🤝 New, expected behavior:

* package name (in `package.json`) is `package-a`
  * *stays the same as before*
* package name (in `package.json`) is `@wix/package-a`
  * Wix internal registry will publish:
    * `package-a`
    * `@wix/package-a`
  * Public npm registry will publish:
    * `@wix/package-a`
* a package that doesn't have wix internal registry as the publish config registry (like `@wix/draft-js`, `yoshi`):
  * Wix internal registry will publish:
    * `@wix/draft-js`
  * Public npm registry will publish:
    * `@wix/draft-js`