### PR TITLE
make publishUnscoped to be on by default

### DIFF
--- a/src/publish-scoped.js
+++ b/src/publish-scoped.js
@@ -120,7 +120,7 @@ export function publishScoped() {
       publishToRegistry(pkg, 'http://npm.dev.wixpress.com/');
       if (!isScoped(bkp.name)) {
         publishToRegistry(pkg, 'https://registry.npmjs.org/');
-      } else if (bkp.publishUnscoped) {
+      } else if (bkp.publishUnscoped !== false) {
         publishUnscopedPackage(bkp);
       }
 


### PR DESCRIPTION
Can be still used for opting out (by passing `false`)