### PR TITLE
add extract-cache and save-cache commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,10 @@
   "html.format.extraLiners": "",
   "files.insertFinalNewline": true,
   "eslint.autoFixOnSave": true,
-  "tslint.autoFixOnSave": true
+  "tslint.autoFixOnSave": true,
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#620208",
+    "titleBar.activeBackground": "#89030B",
+    "titleBar.activeForeground": "#FFFBFC"
+  }
 }

--- a/bin/npm-ci-extract-cache.js
+++ b/bin/npm-ci-extract-cache.js
@@ -1,0 +1,3 @@
+import {extractCache} from '../src/cache';
+
+extractCache();

--- a/bin/npm-ci-save-cache.js
+++ b/bin/npm-ci-save-cache.js
@@ -1,0 +1,3 @@
+import {saveCache} from '../src/cache';
+
+saveCache();

--- a/bin/npm-ci.js
+++ b/bin/npm-ci.js
@@ -4,6 +4,8 @@ const program = require('commander');
 
 program.version(require('../../package').version)
   .command('build', 'build the package')
+  .command('save-cache', 'save the project cache')
+  .command('extract-cache', 'extract the project cache')
   .command('publish', 'publish the package')
   .command('install', 'installs dependencies')
   .command('custom', 'run custom npm command')

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,51 @@
       "integrity": "sha1-BbHljkw/QS7bKKoDRsFMXxPEG0Y=",
       "dev": true
     },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      },
+      "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+          "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+        }
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs="
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc="
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+      "requires": {
+        "@types/events": "3.0.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "6.0.106"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0="
+    },
     "@types/node": {
       "version": "6.0.106",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.106.tgz",
-      "integrity": "sha512-U4Zv5fx7letrisRv6HgSSPSY00FZM4NMIkilt+IAExvQLuNa6jYVwCKcnSs2NqTN4+KDl9PskvcCiMce9iePCA==",
-      "dev": true
+      "integrity": "sha512-U4Zv5fx7letrisRv6HgSSPSY00FZM4NMIkilt+IAExvQLuNa6jYVwCKcnSs2NqTN4+KDl9PskvcCiMce9iePCA=="
     },
     "@types/q": {
       "version": "0.0.32",
@@ -424,20 +464,17 @@
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "dev": true
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
-      "dev": true
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-equal": {
       "version": "1.0.0",
@@ -473,7 +510,6 @@
       "version": "1.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
       "requires": {
         "array-uniq": "1.0.3"
       }
@@ -481,14 +517,12 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.find": {
       "version": "2.0.4",
@@ -560,8 +594,7 @@
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
       "version": "0.9.6",
@@ -601,8 +634,7 @@
     "atob": {
       "version": "2.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
-      "dev": true
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
     "autoprefixer": {
       "version": "7.1.6",
@@ -616,6 +648,53 @@
         "num2fraction": "1.2.2",
         "postcss": "6.0.22",
         "postcss-value-parser": "3.3.0"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.422.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/aws-sdk/-/aws-sdk-2.422.0.tgz",
+      "integrity": "sha1-2HXKQJjO1vR9Rm9Met34p5MyZR8=",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+        }
       }
     },
     "aws-sign2": {
@@ -1813,14 +1892,12 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
-      "dev": true,
       "requires": {
         "cache-base": "1.0.1",
         "class-utils": "0.3.6",
@@ -1835,7 +1912,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "1.0.2"
           }
@@ -1844,7 +1920,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -1853,7 +1928,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -1862,7 +1936,6 @@
           "version": "1.0.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "1.0.0",
             "is-data-descriptor": "1.0.0",
@@ -1880,8 +1953,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM=",
-      "dev": true
+      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM="
     },
     "base64id": {
       "version": "1.0.0",
@@ -1999,7 +2071,6 @@
       "version": "1.1.11",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -2009,7 +2080,6 @@
       "version": "2.3.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
-      "dev": true,
       "requires": {
         "arr-flatten": "1.1.0",
         "array-unique": "0.3.2",
@@ -2027,7 +2097,6 @@
           "version": "2.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "0.1.1"
           }
@@ -2156,7 +2225,6 @@
       "version": "4.9.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
       "requires": {
         "base64-js": "1.3.0",
         "ieee754": "1.1.11",
@@ -2226,7 +2294,6 @@
       "version": "1.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
-      "dev": true,
       "requires": {
         "collection-visit": "1.0.0",
         "component-emitter": "1.2.1",
@@ -2238,6 +2305,11 @@
         "union-value": "1.0.0",
         "unset-value": "1.0.0"
       }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -2552,7 +2624,6 @@
       "version": "0.3.6",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
-      "dev": true,
       "requires": {
         "arr-union": "3.1.0",
         "define-property": "0.2.5",
@@ -2564,7 +2635,6 @@
           "version": "0.2.5",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "0.1.6"
           }
@@ -2703,7 +2773,6 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "dev": true,
       "requires": {
         "map-visit": "1.0.0",
         "object-visit": "1.0.1"
@@ -2802,8 +2871,7 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "component-inherit": {
       "version": "0.0.3",
@@ -2814,8 +2882,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -2982,8 +3049,7 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
       "version": "2.5.5",
@@ -3099,8 +3165,7 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "css": {
       "version": "2.2.1",
@@ -3570,7 +3635,6 @@
       "version": "2.6.9",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -3594,8 +3658,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -3635,7 +3698,6 @@
       "version": "2.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
-      "dev": true,
       "requires": {
         "is-descriptor": "1.0.2",
         "isobject": "3.0.1"
@@ -3645,7 +3707,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -3654,7 +3715,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -3663,7 +3723,6 @@
           "version": "1.0.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "1.0.0",
             "is-data-descriptor": "1.0.0",
@@ -3697,6 +3756,22 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        }
       }
     },
     "delayed-stream": {
@@ -4655,8 +4730,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "dev": true
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -4767,7 +4841,6 @@
       "version": "2.1.4",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "define-property": "0.2.5",
@@ -4782,7 +4855,6 @@
           "version": "0.2.5",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "0.1.6"
           }
@@ -4791,7 +4863,6 @@
           "version": "2.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "0.1.1"
           }
@@ -4895,7 +4966,6 @@
       "version": "3.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "dev": true,
       "requires": {
         "assign-symbols": "1.0.0",
         "is-extendable": "1.0.1"
@@ -4905,7 +4975,6 @@
           "version": "1.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "dev": true,
           "requires": {
             "is-plain-object": "2.0.4"
           }
@@ -4927,7 +4996,6 @@
       "version": "2.0.4",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
-      "dev": true,
       "requires": {
         "array-unique": "0.3.2",
         "define-property": "1.0.0",
@@ -4943,7 +5011,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "1.0.2"
           }
@@ -4952,7 +5019,6 @@
           "version": "2.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "0.1.1"
           }
@@ -4961,7 +5027,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -4970,7 +5035,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -4979,7 +5043,6 @@
           "version": "1.0.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "1.0.0",
             "is-data-descriptor": "1.0.0",
@@ -5067,6 +5130,53 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.6",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fast-glob/-/fast-glob-2.2.6.tgz",
+      "integrity": "sha1-pdW2l+yN7aRo2Fp0A1KQoCWpUpU=",
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.3",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.3",
+        "micromatch": "3.1.10"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -5182,7 +5292,6 @@
       "version": "4.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-      "dev": true,
       "requires": {
         "extend-shallow": "2.0.1",
         "is-number": "3.0.0",
@@ -5194,7 +5303,6 @@
           "version": "2.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "0.1.1"
           }
@@ -5326,8 +5434,7 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
@@ -5369,7 +5476,6 @@
       "version": "0.2.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "dev": true,
       "requires": {
         "map-cache": "0.2.2"
       }
@@ -5416,6 +5522,14 @@
         "klaw": "1.3.1"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
+      "requires": {
+        "minipass": "2.3.5"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -5431,8 +5545,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.3",
@@ -5888,6 +6001,15 @@
           "dev": true,
           "optional": true
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5896,15 +6018,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -6059,8 +6172,7 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
@@ -6126,17 +6238,71 @@
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
+      "version": "9.1.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/globby/-/globby-9.1.0.tgz",
+      "integrity": "sha1-6Q9NUTQQnm2FWr3TG9sbCFQoWS4=",
       "requires": {
+        "@types/glob": "7.1.1",
         "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "dir-glob": "2.2.2",
+        "fast-glob": "2.2.6",
+        "glob": "7.1.3",
+        "ignore": "4.0.6",
+        "pify": "4.0.1",
+        "slash": "2.0.0"
+      },
+      "dependencies": {
+        "dir-glob": {
+          "version": "2.2.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/dir-glob/-/dir-glob-2.2.2.tgz",
+          "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
+          "requires": {
+            "path-type": "3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw="
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+          "requires": {
+            "pify": "3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q="
+        }
       }
     },
     "globjoin": {
@@ -6417,7 +6583,6 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "dev": true,
       "requires": {
         "get-value": "2.0.6",
         "has-values": "1.0.0",
@@ -6428,7 +6593,6 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "dev": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -6438,7 +6602,6 @@
           "version": "4.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -7012,8 +7175,7 @@
     "ieee754": {
       "version": "1.1.11",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha1-wWOE/+APW3g1gk5ntvK9RKUilFU=",
-      "dev": true
+      "integrity": "sha1-wWOE/+APW3g1gk5ntvK9RKUilFU="
     },
     "iferr": {
       "version": "0.1.5",
@@ -7071,7 +7233,6 @@
       "version": "1.0.6",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -7080,8 +7241,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -7181,7 +7341,6 @@
       "version": "0.1.6",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       },
@@ -7190,7 +7349,6 @@
           "version": "3.2.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -7237,8 +7395,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-      "dev": true
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -7268,7 +7425,6 @@
       "version": "0.1.4",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       },
@@ -7277,7 +7433,6 @@
           "version": "3.2.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -7300,7 +7455,6 @@
       "version": "0.1.6",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-      "dev": true,
       "requires": {
         "is-accessor-descriptor": "0.1.6",
         "is-data-descriptor": "0.1.4",
@@ -7310,8 +7464,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-          "dev": true
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         }
       }
     },
@@ -7339,8 +7492,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
@@ -7385,7 +7537,6 @@
       "version": "3.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       },
@@ -7394,7 +7545,6 @@
           "version": "3.2.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -7411,7 +7561,6 @@
       "version": "2.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-odd/-/is-odd-2.0.0.tgz",
       "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
-      "dev": true,
       "requires": {
         "is-number": "4.0.0"
       },
@@ -7419,8 +7568,7 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
-          "dev": true
+          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8="
         }
       }
     },
@@ -7458,7 +7606,6 @@
       "version": "2.0.4",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
-      "dev": true,
       "requires": {
         "isobject": "3.0.1"
       }
@@ -7558,8 +7705,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
-      "dev": true
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
     },
     "is-word-character": {
       "version": "1.0.2",
@@ -7570,8 +7716,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -7588,8 +7733,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -8693,6 +8837,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-base64": {
       "version": "2.4.3",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/js-base64/-/js-base64-2.4.3.tgz",
@@ -8968,8 +9117,7 @@
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-      "dev": true
+      "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
     },
     "klaw": {
       "version": "1.3.1",
@@ -9589,8 +9737,7 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
       "version": "1.0.1",
@@ -9602,7 +9749,6 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "dev": true,
       "requires": {
         "object-visit": "1.0.1"
       }
@@ -9715,6 +9861,11 @@
         "readable-stream": "2.3.6"
       }
     },
+    "merge2": {
+      "version": "1.2.3",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/merge2/-/merge2-1.2.3.tgz",
+      "integrity": "sha1-fumdvWm7ZIFoklPwGEiKG5ArDtU="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/methods/-/methods-1.1.2.tgz",
@@ -9725,7 +9876,6 @@
       "version": "3.1.10",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
-      "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
@@ -10055,7 +10205,6 @@
       "version": "3.0.4",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -10074,6 +10223,30 @@
       "requires": {
         "arrify": "1.0.1",
         "is-plain-obj": "1.1.0"
+      }
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha1-ys6+SSAiSX9law8PUeJoKp7S2Eg=",
+      "requires": {
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha1-3SfqYTYkPHyIBoToZyuzpF/ZthQ=",
+      "requires": {
+        "minipass": "2.3.5"
       }
     },
     "mississippi": {
@@ -10098,7 +10271,6 @@
       "version": "1.3.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
-      "dev": true,
       "requires": {
         "for-in": "1.0.2",
         "is-extendable": "1.0.1"
@@ -10108,7 +10280,6 @@
           "version": "1.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-          "dev": true,
           "requires": {
             "is-plain-object": "2.0.4"
           }
@@ -10137,7 +10308,6 @@
       "version": "0.5.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -10145,8 +10315,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -10250,8 +10419,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "murmurhash": {
       "version": "0.0.2",
@@ -10310,7 +10478,6 @@
       "version": "1.2.9",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
-      "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
@@ -10506,6 +10673,17 @@
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         }
       }
     },
@@ -10779,7 +10957,6 @@
       "version": "0.1.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "dev": true,
       "requires": {
         "copy-descriptor": "0.1.1",
         "define-property": "0.2.5",
@@ -10790,7 +10967,6 @@
           "version": "0.2.5",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "0.1.6"
           }
@@ -10799,7 +10975,6 @@
           "version": "3.2.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -10822,7 +10997,6 @@
       "version": "1.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "dev": true,
       "requires": {
         "isobject": "3.0.1"
       }
@@ -10853,7 +11027,6 @@
       "version": "1.3.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "dev": true,
       "requires": {
         "isobject": "3.0.1"
       }
@@ -10871,7 +11044,6 @@
       "version": "1.4.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -11148,8 +11320,7 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
       "version": "0.0.0",
@@ -11160,8 +11331,7 @@
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -11172,8 +11342,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -11359,8 +11528,7 @@
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
       "version": "6.0.22",
@@ -13908,8 +14076,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -14235,7 +14402,6 @@
       "version": "1.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
-      "dev": true,
       "requires": {
         "extend-shallow": "3.0.2",
         "safe-regex": "1.1.0"
@@ -14352,14 +14518,12 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
@@ -14508,8 +14672,7 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "resolve-url-loader": {
       "version": "2.3.0",
@@ -14555,8 +14718,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
-      "dev": true
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
     },
     "rework": {
       "version": "1.0.1",
@@ -14705,7 +14867,6 @@
       "version": "1.1.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "dev": true,
       "requires": {
         "ret": "0.1.15"
       }
@@ -14795,8 +14956,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
-      "dev": true
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "schema-utils": {
       "version": "0.4.5",
@@ -14955,7 +15115,6 @@
       "version": "2.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
-      "dev": true,
       "requires": {
         "extend-shallow": "2.0.1",
         "is-extendable": "0.1.1",
@@ -14967,7 +15126,6 @@
           "version": "2.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "0.1.1"
           }
@@ -15116,7 +15274,6 @@
       "version": "0.8.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
-      "dev": true,
       "requires": {
         "base": "0.11.2",
         "debug": "2.6.9",
@@ -15132,7 +15289,6 @@
           "version": "0.2.5",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "0.1.6"
           }
@@ -15141,7 +15297,6 @@
           "version": "2.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "0.1.1"
           }
@@ -15149,8 +15304,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -15158,7 +15312,6 @@
       "version": "2.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
-      "dev": true,
       "requires": {
         "define-property": "1.0.0",
         "isobject": "3.0.1",
@@ -15169,7 +15322,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "1.0.2"
           }
@@ -15178,7 +15330,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -15187,7 +15338,6 @@
           "version": "1.0.0",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           }
@@ -15196,7 +15346,6 @@
           "version": "1.0.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-          "dev": true,
           "requires": {
             "is-accessor-descriptor": "1.0.0",
             "is-data-descriptor": "1.0.0",
@@ -15209,7 +15358,6 @@
       "version": "3.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       },
@@ -15218,7 +15366,6 @@
           "version": "3.2.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -15402,7 +15549,6 @@
       "version": "0.5.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
-      "dev": true,
       "requires": {
         "atob": "2.1.1",
         "decode-uri-component": "0.2.0",
@@ -15431,8 +15577,7 @@
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spawn-sync": {
       "version": "1.0.15",
@@ -15486,7 +15631,6 @@
       "version": "3.1.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
-      "dev": true,
       "requires": {
         "extend-shallow": "3.0.2"
       }
@@ -15544,7 +15688,6 @@
       "version": "0.1.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "dev": true,
       "requires": {
         "define-property": "0.2.5",
         "object-copy": "0.1.0"
@@ -15554,7 +15697,6 @@
           "version": "0.2.5",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
           "requires": {
             "is-descriptor": "0.1.6"
           }
@@ -15621,6 +15763,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/string-length/-/string-length-1.0.1.tgz",
@@ -15639,15 +15790,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
       }
     },
     "stringify-entities": {
@@ -16499,27 +16641,40 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
+      "version": "4.4.8",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha1-sZ7sP94qluZGZt+f20DFyhvDdH0=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "chownr": "1.1.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.5",
+        "minizlib": "1.2.1",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "1.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ="
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek="
+        }
       }
     },
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-      "dev": true
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
     },
     "tempy": {
       "version": "0.2.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tempy/-/tempy-0.2.1.tgz",
       "integrity": "sha1-kDjk29HCAbdEciFBebwsb3d25Uw=",
-      "dev": true,
       "requires": {
         "temp-dir": "1.0.0",
         "unique-string": "1.0.0"
@@ -16655,7 +16810,6 @@
       "version": "0.3.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       },
@@ -16664,7 +16818,6 @@
           "version": "3.2.2",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -16675,7 +16828,6 @@
       "version": "3.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
-      "dev": true,
       "requires": {
         "define-property": "2.0.2",
         "extend-shallow": "3.0.2",
@@ -16687,7 +16839,6 @@
       "version": "2.1.1",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "dev": true,
       "requires": {
         "is-number": "3.0.0",
         "repeat-string": "1.6.1"
@@ -17047,7 +17198,6 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-      "dev": true,
       "requires": {
         "arr-union": "3.1.0",
         "get-value": "2.0.6",
@@ -17059,7 +17209,6 @@
           "version": "2.0.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "0.1.1"
           }
@@ -17068,7 +17217,6 @@
           "version": "0.4.3",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
           "requires": {
             "extend-shallow": "2.0.1",
             "is-extendable": "0.1.1",
@@ -17121,7 +17269,6 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
       "requires": {
         "crypto-random-string": "1.0.0"
       }
@@ -17184,7 +17331,6 @@
       "version": "1.0.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "dev": true,
       "requires": {
         "has-value": "0.3.1",
         "isobject": "3.0.1"
@@ -17194,7 +17340,6 @@
           "version": "0.3.1",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "dev": true,
           "requires": {
             "get-value": "2.0.6",
             "has-values": "0.1.4",
@@ -17205,7 +17350,6 @@
               "version": "2.1.0",
               "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -17215,8 +17359,7 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
     },
@@ -17244,8 +17387,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",
@@ -17295,7 +17437,6 @@
       "version": "3.1.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/use/-/use-3.1.0.tgz",
       "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
-      "dev": true,
       "requires": {
         "kind-of": "6.0.2"
       }
@@ -17957,8 +18098,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -18027,7 +18167,6 @@
       "version": "0.4.19",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
-      "dev": true,
       "requires": {
         "sax": "1.2.4",
         "xmlbuilder": "9.0.7"
@@ -18036,8 +18175,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmldom": {
       "version": "0.1.27",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,16 @@
     "yoshi": "^2.1.4"
   },
   "dependencies": {
+    "aws-sdk": "^2.422.0",
     "babel-runtime": "~6.25.0",
     "chalk": "^2.4.1",
     "commander": "^2.15.1",
+    "globby": "^9.1.0",
     "lodash": "^4.17.10",
     "request": "^2.88.0",
-    "semver": "^5.5.0"
+    "semver": "^5.5.0",
+    "tar": "^4.4.8",
+    "tempy": "^0.2.1"
   },
   "babel": {
     "plugins": [

--- a/src/build.js
+++ b/src/build.js
@@ -1,10 +1,18 @@
 import {execCommand} from './utils';
 import {setApplitoolsId} from './applitoolsScripts';
 import {install} from './install';
+import {extractCache, saveCache} from './cache';
 
 export async function build(buildType) {
   if (process.env.APPLITOOLS_GITHUB_FT) {
     setApplitoolsId();
+  }
+
+  try {
+    await extractCache();
+  } catch (err) {
+    console.log('An error occured while trying to extract cache. Build will continue without cache.');
+    console.log(err);
   }
 
   await install();
@@ -15,6 +23,14 @@ export async function build(buildType) {
   }
 
   execCommand(`npm run ${buildType}`);
+
+  try {
+    await saveCache();
+  } catch (err) {
+    console.log('An error occured while trying to save cache. Cache will not be updated.');
+    console.log(err);
+  }
+
 }
 
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,69 @@
+const {readFileSync, createReadStream} = require('fs');
+const tar = require('tar');
+const AWS = require('aws-sdk');
+const {sync: globbySync} = require('globby');
+const tempy = require('tempy');
+
+AWS.config.credentials = new AWS.SharedIniFileCredentials({profile: 'automation-aws'});
+
+const CI_CACHE_BUCKET = `ci-cache`;
+const cacheKey = process.env.NPM_CI_CACHE_KEY || `${process.env.system.repo.owner}__${process.env.system.repo}__${process.env.BRANCH}`;
+
+const s3Client = new AWS.S3();
+
+export async function extractCache() {
+  console.log(`Starting to download and extract cache with key ${cacheKey}...`);
+  s3Client.getObject({
+    Bucket: CI_CACHE_BUCKET,
+    Key: cacheKey
+  }).createReadStream()
+    .pipe(tar.extract({}))
+    .on('error', err => console.log('error while downloading and extracting cache', err))
+    .on('end', () => {
+      console.log(`Finished downloading and extracting cache.`);
+    });
+}
+
+export async function saveCache() {
+  const ciConfig = JSON.parse(readFileSync('.ci_config', 'utf8'));
+
+  if (!ciConfig.cache) {
+    console.log('No cache config in .ci_config. Skipping cache creation.');
+  } else {
+    console.log('Found cache config for the following path globs:');
+    ciConfig.cache.paths.forEach(console.log.bind(console));
+
+    const pathsToCache = globbySync(ciConfig.cache.paths, {
+      onlyFiles: false,
+      expandDirectories: false
+    });
+
+    console.log('Expanded the globs to the following paths to cache:');
+    pathsToCache.forEach(console.log.bind(console));
+
+    const tempFile = tempy.file({extension: 'tar.gz'});
+
+    console.log(`Creating tar.gz of cache paths at ${tempFile}...`);
+    await tar.create({
+      gzip: true,
+      file: tempFile
+    }, pathsToCache);
+    console.log('Cache file created.');
+
+    const cacheKey = process.env.NPM_CI_CACHE_KEY;
+
+    console.log(`Uploading cache to S3 under key ${cacheKey}...`);
+    s3Client.upload({
+      Body: createReadStream(tempFile),
+      Bucket: CI_CACHE_BUCKET,
+      Key: cacheKey
+    }, err => {
+      if (err) {
+        console.log('Encountered an error when uploading cache to s3.');
+        console.error(err);
+      } else {
+        console.log(`Cache file uploaded successfully`);
+      }
+    });
+  }
+}

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,4 +1,4 @@
-const {readFileSync, createReadStream} = require('fs');
+const {readFileSync, createReadStream, existsSync} = require('fs');
 const tar = require('tar');
 const AWS = require('aws-sdk');
 const {sync: globbySync} = require('globby');
@@ -25,6 +25,11 @@ export async function extractCache() {
 }
 
 export async function saveCache() {
+  if (!existsSync('.ci_config')) {
+    console.log('No .ci_config file found. Skipping cache creation.');
+    return;
+  }
+
   const ciConfig = JSON.parse(readFileSync('.ci_config', 'utf8'));
 
   if (!ciConfig.cache) {


### PR DESCRIPTION
Initial implementation of the cache commands for npm-ci.
Assumes AWS credentials exist on the build agent (works the same for other CI builds that use s3).

Design decisions:
* Based on `.ci_config`. We can come up with some heuristic on how to get the paths that need to be cached. I'd rather start with explicitness and if we are building upon the `.ci_config` file, I guess that is a good place to put it. (under `cache.paths`).
* The default cache key is going to be `ORG_REPO_BRANCH`. That means the cache is shared per branch build inside a repo. In pull requests, that means the first build of the branch will not have a cache, but subsequent builds will. (Maybe take the first cache from master? Check if the cache for the branch exists and fallback to master (and have master hard-coded as a base branch)? need to think about it). On long-lived branches, most of the builds will have the cache.

