### PR TITLE
Fix cache commands

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -4,7 +4,9 @@ const AWS = require('aws-sdk');
 const {sync: globbySync} = require('globby');
 const tempy = require('tempy');
 
-AWS.config.credentials = new AWS.SharedIniFileCredentials({profile: 'automation-aws'});
+AWS.config.credentials = process.env.NPM_CI_AWS_ACCESS_KEY ?
+  new AWS.Credentials(process.env.NPM_CI_AWS_ACCESS_KEY, process.env.NPM_CI_AWS_SECRET_ACCESS_KEY) :
+  new AWS.SharedIniFileCredentials({profile: 'automation-aws'});
 
 const cacheKey = process.env.NPM_CI_CACHE_KEY || `${process.env.TEAMCITY_PROJECT_NAME}__${process.env.BRANCH}`;
 


### PR DESCRIPTION
A few changes and fixes for configuring the cache mechanism.
* can override the bucket to save in using an env variable -> `.ci_config` -> default
* Allow override the credentials for AWS using env vars (easier debugging for me, but could be useable)
* a small fix for the cache - now using `TEAMCITY_PROJECT_NAME` which I assume is unique (looks like the env vars for the org and repo couldn't be found).