### PR TITLE
add commands for handling run results

### DIFF
--- a/bin/npm-ci-check-run-result.js
+++ b/bin/npm-ci-check-run-result.js
@@ -1,0 +1,12 @@
+import {checkRunResult} from '../src/run-results';
+
+const program = require('commander');
+
+program.version(require('../../package').version)
+  .usage('hash command')
+  .parse(process.argv);
+
+const hash = program.args[0];
+const command = program.args[1];
+
+checkRunResult(hash, command).then(didPass => process.exit(didPass ? 0 : 1));

--- a/bin/npm-ci-hash-folder.js
+++ b/bin/npm-ci-hash-folder.js
@@ -1,0 +1,3 @@
+import {getHashForCWD} from '../src/utils';
+
+getHashForCWD().then(console.log);

--- a/bin/npm-ci-save-successful-run.js
+++ b/bin/npm-ci-save-successful-run.js
@@ -1,0 +1,12 @@
+import {saveSuccessfulRun} from '../src/run-results';
+
+const program = require('commander');
+
+program.version(require('../../package').version)
+  .usage('hash command')
+  .parse(process.argv);
+
+const hash = program.args[0];
+const command = program.args[1];
+
+saveSuccessfulRun(hash, command).then(didSave => process.exit(didSave ? 0 : 1));

--- a/bin/npm-ci.js
+++ b/bin/npm-ci.js
@@ -9,4 +9,7 @@ program.version(require('../../package').version)
   .command('publish', 'publish the package')
   .command('install', 'installs dependencies')
   .command('custom', 'run custom npm command')
+  .command('hash-folder', 'print the calculated hash for the folder and it\'s contents')
+  .command('check-run-result', 'exit with 0 if provided hash and command was previously successful, 1 otherwise')
+  .command('save-successful-run', 'save a successful run with a provided hash and command')
   .parse(process.argv);

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,17 +1,15 @@
 import {readFileSync, createReadStream, existsSync} from 'fs';
 import tar from 'tar';
-import AWS from 'aws-sdk';
+import {S3} from 'aws-sdk';
 import {sync as globbySync} from 'globby';
 import tempy from 'tempy';
-import {getCurrentProjectUniqueIdentifier} from './utils';
-
-AWS.config.credentials = process.env.NPM_CI_AWS_ACCESS_KEY ?
-  new AWS.Credentials(process.env.NPM_CI_AWS_ACCESS_KEY, process.env.NPM_CI_AWS_SECRET_ACCESS_KEY) :
-  new AWS.SharedIniFileCredentials({profile: process.env.NPM_CI_AWS_CREDENTIALS_PROFILE});
+import {getAWSCredentials, getCurrentProjectUniqueIdentifier} from './utils';
 
 const cacheKey = `${getCurrentProjectUniqueIdentifier()}/${process.env.NPM_CI_CACHE_KEY || process.env.BRANCH}`;
 
-const s3Client = new AWS.S3();
+const s3Client = new S3({
+  credentials: getAWSCredentials()
+});
 
 function getCICacheBucket(ciConfig) {
   const ciConfigBucketName = ciConfig.cache && ciConfig.cache.bucket;

--- a/src/run-results.js
+++ b/src/run-results.js
@@ -1,0 +1,46 @@
+import {S3} from 'aws-sdk';
+import {getAWSCredentials, getCurrentProjectUniqueIdentifier} from './utils';
+
+const s3Client = new S3({
+  credentials: getAWSCredentials()
+});
+
+const CI_RESULTS_BUCKET = process.env.NPM_CI_RESULTS_BUCKET || 'wix-ci-results';
+
+export async function checkRunResult(hash, command) {
+  const buildHistoryKey = `${getCurrentProjectUniqueIdentifier()}/${hash}/${command}`;
+
+  let didPass;
+
+  try {
+    await s3Client.headObject({
+      Bucket: CI_RESULTS_BUCKET,
+      Key: buildHistoryKey
+    }).promise();
+
+    didPass = true;
+  } catch (err) {
+    didPass = false;
+  }
+
+  return didPass;
+}
+
+export async function saveSuccessfulRun(hash, command) {
+  const buildHistoryKey = `${getCurrentProjectUniqueIdentifier()}/${hash}/${command}`;
+
+  let didSave;
+
+  try {
+    await s3Client.putObject({
+      Bucket: CI_RESULTS_BUCKET,
+      Key: buildHistoryKey,
+      Body: 'true'
+    }).promise();
+
+    didSave = true;
+  } catch (err) {
+    didSave = false;
+  }
+  return didSave;
+}


### PR DESCRIPTION
Added some commands to work with run results, which would give us the possibility to use this also from `npmBuild.sh` or `smartNpmBuild.sh`.

The 3 commands are:
	* `hash-folder`: prints to the console the hash of the current directory.
	* `check-run-result`: exits with 0 if the given hash and command were previously run successfully, 1 otherwise.
	* `save-successful-run`: Saves a successful run for the given hash and command