### PR TITLE
add support for temp and re-publish for parallel publish

### DIFF
--- a/bin/npm-ci-publish.js
+++ b/bin/npm-ci-publish.js
@@ -10,6 +10,15 @@ import {
 import { writeFileSync, unlinkSync } from 'fs';
 import { execSync } from 'child_process';
 
+const program = require('commander');
+
+// eslint-disable-next-line
+program.version(require('../../package').version)
+  .usage('[publish-type]')
+  .parse(process.argv);
+
+const requestedPublishType = program.args[0];
+
 function latest(registry) {
   try {
     const result = JSON.parse(
@@ -24,14 +33,17 @@ function latest(registry) {
   }
 }
 
-async function runPublish() {
+/**
+ * @param {import("../src/publish").PublishType} [publishType] The type of publish to perform
+ */
+async function runPublish(publishType) {
   logBlockOpen('npm publish');
-  await publish();
+  await publish(undefined, publishType);
   logBlockClose('npm publish');
 
   if (process.env.PUBLISH_SCOPED) {
     logBlockOpen('npm publish to wix scope');
-    await publishScoped();
+    await publishScoped(publishType);
     logBlockClose('npm publish to wix scope');
   }
 }
@@ -93,6 +105,6 @@ execCommandAsync('npm run release --if-present').then(({ stdio }) => {
       `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; No publish']`,
     );
   } else {
-    runPublish();
+    runPublish(requestedPublishType);
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1938,9 +1938,9 @@
       }
     },
     "@wix/npm-republish": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@wix/npm-republish/-/npm-republish-0.1.1.tgz",
-      "integrity": "sha512-FKZy7X9ZBE0YkNJ/YoDv8qTptqWc/8pxr2kGKKcAOEiFABAum4GY0lwUFLXiEEodiHFPuQw6leU84ASg4yqz+Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wix/npm-republish/-/npm-republish-0.2.0.tgz",
+      "integrity": "sha512-lzwrqhFdc6VbiZ6Ecmv4NsZb2nBhRtDLDqU+FZxgPMs8ZN6+8J5suQPtaf/jlo8tf/U2D7SqNh5SJ5eGKslD4Q==",
       "requires": {
         "tar": "^4.4.8",
         "tempy": "^0.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1937,6 +1937,27 @@
         "lodash": "^4.17.10"
       }
     },
+    "@wix/npm-republish": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@wix/npm-republish/-/npm-republish-0.1.1.tgz",
+      "integrity": "sha512-FKZy7X9ZBE0YkNJ/YoDv8qTptqWc/8pxr2kGKKcAOEiFABAum4GY0lwUFLXiEEodiHFPuQw6leU84ASg4yqz+Q==",
+      "requires": {
+        "tar": "^4.4.8",
+        "tempy": "^0.3.0"
+      },
+      "dependencies": {
+        "tempy": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.3.0.tgz",
+          "integrity": "sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==",
+          "requires": {
+            "temp-dir": "^1.0.0",
+            "type-fest": "^0.3.1",
+            "unique-string": "^1.0.0"
+          }
+        }
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -17473,6 +17494,11 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.2",
-    "@wix/npm-republish": "^0.1.1",
+    "@wix/npm-republish": "^0.2.0",
     "aws-sdk": "^2.424.0",
     "babel-runtime": "~6.25.0",
     "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.2",
+    "@wix/npm-republish": "^0.1.1",
     "aws-sdk": "^2.424.0",
     "babel-runtime": "~6.25.0",
     "chalk": "^2.4.1",

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,8 +1,13 @@
-import { readJsonFile, execCommandAsync } from './utils';
+import { readJsonFile, execCommandAsync, writeJsonFile } from './utils';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
 import semver from 'semver';
 import { get } from 'lodash';
+import { republishPackage } from '@wix/npm-republish';
+
+/**
+ * @typedef {"temp-publish" | "re-publish"} PublishType
+ */
 
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 const LATEST_TAG = 'latest';
@@ -56,25 +61,31 @@ function getTag(info, version) {
   }
 }
 
-async function execPublish(info, version, flags) {
-  const publishCommand = `npm publish --tag=${getTag(
-    info,
-    version,
-  )} ${flags}`.trim();
+function getUnverifiedVersion(version) {
+  return `${version}-unverified`;
+}
+
+async function execPublish(info, version, flags, tagOverride) {
+  const publishCommand = `npm publish --tag=${tagOverride ||
+    getTag(info, version)} ${flags}`.trim();
   console.log(
     chalk.magenta(`Running: "${publishCommand}" for ${info.name}@${version}`),
   );
   return execCommandAsync(publishCommand);
 }
 
-// 1. verify that the package can be published by checking the registry.
-//   (Can only publish versions that doesn't already exist)
-// 2. choose a tag ->
-// * `old` for a release that is less than latest (semver).
-// * `next` for a prerelease (beta/alpha/rc).
-// * `latest` as default.
-// 3. perform npm publish using the chosen tag.
-export async function publish(flags = '') {
+/**
+ * 1. verify that the package can be published by checking the registry.
+ *  (Can only publish versions that doesn't already exist)
+ * 2. choose a tag ->
+ * `old` for a release that is less than latest (semver).
+ * `next` for a prerelease (beta/alpha/rc).
+ * `latest` as default.
+ * 3. perform npm publish using the chosen tag.
+ * @param {string} flags Flags to pass to npm publush
+ * @param {PublishType} [publishType] The type of publish to perform
+ */
+export async function publish(flags = '', publishType) {
   const pkg = readJsonFile('package.json');
   const registry = get(pkg, 'publishConfig.registry', DEFAULT_REGISTRY);
   const info = getPackageInfo(registry);
@@ -91,16 +102,64 @@ export async function publish(flags = '') {
       `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; No publish']`,
     );
   } else {
-    await execPublish(
-      info,
-      version,
-      flags + ` --registry=${registry} --@wix:registry=${registry}`,
-    );
-    console.log(
-      chalk.green(`\nPublish "${name}@${version}" successfully to ${registry}`),
-    );
-    console.log(
-      `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; Published: ${name}@${version}']`,
-    );
+    if (!publishType) {
+      await execPublish(
+        info,
+        version,
+        flags + ` --registry=${registry} --@wix:registry=${registry}`,
+      );
+      console.log(
+        chalk.green(
+          `\nPublish "${name}@${version}" successfully to ${registry}`,
+        ),
+      );
+      console.log(
+        `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; Published: ${name}@${version}']`,
+      );
+    } else if (publishType === 'temp-publish') {
+      // in case of a temp publish, we want to publish a prerelease version
+      // that will later become the real version (using re-publish). For that
+      // we also remove the postpublish step, becuase this is not the real publish
+      const unverifiedVersion = getUnverifiedVersion(version);
+      const pkgJson = readJsonFile('package.json');
+      pkgJson.scripts && delete pkgJson.scripts.postPublish;
+      pkgJson.version = unverifiedVersion;
+      writeJsonFile('package.json', pkgJson);
+
+      await execPublish(
+        info,
+        unverifiedVersion,
+        flags + ` --registry=${registry} --@wix:registry=${registry}`,
+        'unverified',
+      );
+
+      console.log(
+        chalk.green(
+          `\nPublish "${name}@${unverifiedVersion}" successfully to ${registry}`,
+        ),
+      );
+      console.log(
+        `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; Published unverified version: ${name}@${unverifiedVersion}']`,
+      );
+    } else if (publishType === 're-publish') {
+      const pkgJson = readJsonFile('package.json');
+      const unverifiedVersion = getUnverifiedVersion(pkgJson.version);
+
+      republishPackage(
+        `${pkgJson.name}@${unverifiedVersion}`,
+        pkgJson.version,
+        [
+          flags.split(' '),
+          `--registry=${registry}`,
+          `--@wix:registry=${registry}`,
+        ],
+      );
+
+      // Since we didn't run the postpublish script in the temp publish, we should run the postpublish
+      // after a re-publish
+      await execCommandAsync('npm run postpublish');
+    } else {
+      throw new Error(`Unknown publish type requested ${publishType}`);
+    }
   }
 }


### PR DESCRIPTION
Added support for two option for `npm-ci publish`: `re-publish` and `temp-publish`. This is to support a parallel publish before the tests finish.

We publish a prerelease with the `unverified` identifier in the `temp-publish` with the `unverified` tag. When the tests finish, the build will run a `re-publish` which will take the `unverified` version and re-publish it as the real version.

Also makes sure to only run the `postpublish` script on a `re-publish` (which is the real publish of the package).