### PR TITLE
add logs to applitools script

### DIFF
--- a/src/applitoolsScripts.js
+++ b/src/applitoolsScripts.js
@@ -16,10 +16,12 @@ function getParentsHashArray() {
 
 function getPRHeadHash() {
   const parentsHashArr = getParentsHashArray();
+  console.log('getPRHeadHash:parentsHashArr=', parentsHashArr);
   const isPullRequest = parentsHashArr.length === 3;
   const parentHashIndex = isPullRequest
     ? PULL_REQUEST_PARENT_HASH_INDEX
     : HEAD_HASH_INDEX;
+  console.log('getPRHeadHash-parentsHashArr[parentHashIndex].trim():', parentsHashArr[parentHashIndex].trim());
   return parentsHashArr[parentHashIndex].trim();
 }
 
@@ -27,8 +29,10 @@ export function setApplitoolsId() {
   let batchId;
   try {
     batchId = getPRHeadHash();
+    console.log('batchId', batchId);
   } catch (e) {
     batchId = process.env.BUILD_VCS_NUMBER;
+    console.log('batchId', batchId);
   }
   process.env.APPLITOOLS_BATCH_ID = batchId;
 }


### PR DESCRIPTION
@netanelgilad @shlomitc @jonathanadler
Each PR in WSR run Applitools tests twice (in parallel)
new test config always fail on applitools failiure
https://github.com/wix/wix-style-react/pull/3574
continuous-integration/teamcity - pass
test - fail

failure reason - Applitools is comparing the PR branch to some default old branch instead of comparing it to master.

for some reason the new build config (test) is not integrating well with Applitools.
PR purpose is to debug the batch id that we send to Applitools.


