### PR TITLE
temp and republish uses source md5 to set unverified publish version

### DIFF
--- a/bin/npm-ci-publish.js
+++ b/bin/npm-ci-publish.js
@@ -18,6 +18,7 @@ program.version(require('../../package').version)
   .parse(process.argv);
 
 const requestedPublishType = program.args[0];
+const providedSourceMD5 = program.args[1];
 
 function latest(registry) {
   try {
@@ -35,15 +36,16 @@ function latest(registry) {
 
 /**
  * @param {import("../src/publish").PublishType} [publishType] The type of publish to perform
+ * @param {string} sourceMD5 The MD5 of the repository source
  */
-async function runPublish(publishType) {
+async function runPublish(publishType, sourceMD5) {
   logBlockOpen('npm publish');
-  await publish(undefined, publishType);
+  await publish(undefined, publishType, sourceMD5);
   logBlockClose('npm publish');
 
   if (process.env.PUBLISH_SCOPED) {
     logBlockOpen('npm publish to wix scope');
-    await publishScoped(publishType);
+    await publishScoped(publishType, sourceMD5);
     logBlockClose('npm publish to wix scope');
   }
 }
@@ -105,6 +107,6 @@ execCommandAsync('npm run release --if-present').then(({ stdio }) => {
       `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; No publish']`,
     );
   } else {
-    runPublish(requestedPublishType);
+    runPublish(requestedPublishType, providedSourceMD5);
   }
 });

--- a/src/publish.js
+++ b/src/publish.js
@@ -68,8 +68,8 @@ function getTag(info, version) {
   }
 }
 
-function getUnverifiedVersion(version) {
-  return `${version}-unverified`;
+function getUnverifiedPublishVersion(sourceMD5) {
+  return `0.0.0-${sourceMD5}`;
 }
 
 function stringHasForbiddenCantPublish(str) {
@@ -133,8 +133,9 @@ async function execPublish(info, version, flags, tagOverride) {
  * 3. perform npm publish using the chosen tag.
  * @param {string} flags Flags to pass to npm publush
  * @param {PublishType} [publishType] The type of publish to perform
+ * @param {string} sourceMD5 The MD5 of the repository source
  */
-export async function publish(flags = '', publishType) {
+export async function publish(flags = '', publishType, sourceMD5) {
   const pkg = readJsonFile('package.json');
   const registry = get(pkg, 'publishConfig.registry', DEFAULT_REGISTRY);
   const info = getPackageInfo(registry);
@@ -169,7 +170,7 @@ export async function publish(flags = '', publishType) {
       // in case of a temp publish, we want to publish a prerelease version
       // that will later become the real version (using re-publish). For that
       // we also remove the postpublish step, becuase this is not the real publish
-      const unverifiedVersion = getUnverifiedVersion(version);
+      const unverifiedVersion = getUnverifiedPublishVersion(sourceMD5);
       const pkgJson = readJsonFile('package.json');
       pkgJson.scripts && delete pkgJson.scripts.postPublish;
       pkgJson.version = unverifiedVersion;
@@ -192,7 +193,7 @@ export async function publish(flags = '', publishType) {
       );
     } else if (publishType === 're-publish') {
       const pkgJson = readJsonFile('package.json');
-      const unverifiedVersion = getUnverifiedVersion(pkgJson.version);
+      const unverifiedVersion = getUnverifiedPublishVersion(sourceMD5);
 
       republishPackage(
         `${pkgJson.name}@${unverifiedVersion}`,


### PR DESCRIPTION
temp and re-publish will now use the source md5 to publish an unverified version of the package.

The idea: In a pull request, we want to publish a version of the package even if the tests fail, so we can test it out and also see that the publish works well. The version that will be given to the published version of the pull request is a hash of the source repository (in this case `md5`). This hash is the unique identifier of the current state of the package, and it could also be later calculated on master to perform a re-publish. 
Once the PR is merged, in master we can calculate the source md5 and if want to skip running build, tests and publish because it already worked in PR, we can use the source md5 to perform a republish to the real version of the package.