### PR TITLE
avoid running release script on temp publish

### DIFF
--- a/bin/npm-ci-publish.js
+++ b/bin/npm-ci-publish.js
@@ -39,47 +39,53 @@ let pkg = readJsonFile('package.json');
 const previousVersion = pkg.version;
 const shouldUnlink = false;
 
-execCommandAsync('npm run release --if-present').then(({ stdio }) => {
-  if (shouldUnlink) {
-    unlinkSync('.npmrc');
-  }
-  pkg = readJsonFile('package.json');
-  if (
-    pkg.scripts &&
-    pkg.scripts.release &&
-    pkg.scripts.release.indexOf('mltci') > -1
-  ) {
-    console.log(
-      'Detected release mltci, it might publish, so skipping publishing myself',
-    );
-  } else if (pkg.private && previousVersion !== pkg.version) {
-    console.log('forcing republish in order to sync versions');
-    delete pkg.private;
-    writeJsonFile('package.json', pkg);
-  }
+Promise.resolve()
+  .then(() => {
+    if (requestedPublishType !== 'temp-publish') {
+      return execCommandAsync('npm run release --if-present');
+    }
+  })
+  .then(({ stdio }) => {
+    if (shouldUnlink) {
+      unlinkSync('.npmrc');
+    }
+    pkg = readJsonFile('package.json');
+    if (
+      pkg.scripts &&
+      pkg.scripts.release &&
+      pkg.scripts.release.indexOf('mltci') > -1
+    ) {
+      console.log(
+        'Detected release mltci, it might publish, so skipping publishing myself',
+      );
+    } else if (pkg.private && previousVersion !== pkg.version) {
+      console.log('forcing republish in order to sync versions');
+      delete pkg.private;
+      writeJsonFile('package.json', pkg);
+    }
 
-  // eslint-disable-next-line no-div-regex
-  const npmPublishRegex = /[\s\S]*?npm publish[\s\S]*?=== Tarball Details ===[\s\\n]+.*name:\s+([^\s]+)[\s\\n]*.*version:\s+([^\s]+)/gm;
-  const stdoutString = stdio.stdout.toString();
-  let stdOutMatch;
-  let skipPublish = false;
-  while ((stdOutMatch = npmPublishRegex.exec(stdoutString))) {
-    // eslint-disable-line no-cond-assign
-    const [_, pkgName, pkgVersion] = stdOutMatch;
-    console.log(
-      `Seems like 'release' command published a package ${pkgName} ${pkgVersion}`,
-    );
-    skipPublish = true;
-  }
+    // eslint-disable-next-line no-div-regex
+    const npmPublishRegex = /[\s\S]*?npm publish[\s\S]*?=== Tarball Details ===[\s\\n]+.*name:\s+([^\s]+)[\s\\n]*.*version:\s+([^\s]+)/gm;
+    const stdoutString = stdio.stdout.toString();
+    let stdOutMatch;
+    let skipPublish = false;
+    while ((stdOutMatch = npmPublishRegex.exec(stdoutString))) {
+      // eslint-disable-line no-cond-assign
+      const [_, pkgName, pkgVersion] = stdOutMatch;
+      console.log(
+        `Seems like 'release' command published a package ${pkgName} ${pkgVersion}`,
+      );
+      skipPublish = true;
+    }
 
-  if (pkg.private || skipPublish) {
-    skipPublish &&
-      console.log('Skipping publish because release published something');
-    console.log('Skipping publish (probably no change in tarball)');
-    console.log(
-      `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; No publish']`,
-    );
-  } else {
-    runPublish(requestedPublishType, providedSourceMD5);
-  }
-});
+    if (pkg.private || skipPublish) {
+      skipPublish &&
+        console.log('Skipping publish because release published something');
+      console.log('Skipping publish (probably no change in tarball)');
+      console.log(
+        `##teamcity[buildStatus status='SUCCESS' text='{build.status.text}; No publish']`,
+      );
+    } else {
+      runPublish(requestedPublishType, providedSourceMD5);
+    }
+  });


### PR DESCRIPTION
When running a temp publish, the version is set by the script, so there is no need to run the `release` script (which may cause problems when running in a PR)