### PR TITLE
perfer repo check: drop the npx usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2009,6 +2009,11 @@
         }
       }
     },
+    "@wix/perfer-repo-status-cli": {
+      "version": "1.0.7",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/perfer-repo-status-cli/-/@wix/perfer-repo-status-cli-1.0.7.tgz",
+      "integrity": "sha1-Sl/lq4tc2Jvt/fYlYZf8rnmDp/0="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -3467,7 +3472,6 @@
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -6688,8 +6692,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6710,14 +6713,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6732,20 +6733,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6862,8 +6860,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6875,7 +6872,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6890,7 +6886,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6898,14 +6893,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6924,7 +6917,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7005,8 +6997,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7018,7 +7009,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7104,8 +7094,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7141,7 +7130,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7161,7 +7149,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7205,14 +7192,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7854,8 +7839,7 @@
       "version": "2.16.3",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.0",
@@ -11348,7 +11332,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -12320,8 +12303,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.2",
     "@wix/npm-republish": "^0.2.0",
-    "@wix/perfer-repo-status-cli": "latest",
+    "@wix/perfer-repo-status-cli": "^1.0.0",
     "aws-sdk": "^2.424.0",
     "babel-runtime": "~6.25.0",
     "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.2",
     "@wix/npm-republish": "^0.2.0",
+    "@wix/perfer-repo-status-cli": "latest",
     "aws-sdk": "^2.424.0",
     "babel-runtime": "~6.25.0",
     "chalk": "^2.4.1",

--- a/src/build.js
+++ b/src/build.js
@@ -34,7 +34,10 @@ export async function build(buildType) {
   execCommand(`npm run ${buildType}`);
   reportOperationEnded('test');
 
-  execCommand(`npx -p @wix/perfer-repo-status-cli verify`);
+  const repoStatusCLI = require.resolve(
+    '@wix/perfer-repo-status-cli/bundle/index',
+  );
+  execCommand(`${repoStatusCLI} verify`);
 
   try {
     await saveCache();


### PR DESCRIPTION
This caused bug in a specific project, saying that there's no npx command: http://tc.dev.wixpress.com/viewType.html?buildTypeId=Santa_SantaCore_SantaWixCode&branch_Santa_SantaCore=%3Cdefault%3E&tab=buildTypeStatusDiv

so this PR removes the usage of npx by adding `@wix/perfer-repo-status-cli` a dependency